### PR TITLE
feat: add simple fps with wall

### DIFF
--- a/src/game-states/game.state.ts
+++ b/src/game-states/game.state.ts
@@ -3,57 +3,93 @@ import { drawEngine } from '@/core/draw-engine';
 import { controls } from '@/core/controls';
 import { gameStateMachine } from '@/game-state-machine';
 import { menuState } from '@/game-states/menu.state';
-import { renderWebGl } from '@/web-gl/renderer';
-import { clamp } from '@/helpers';
 
+// Simple raycast-based FPS state
 class GameState implements State {
-  ballImage = new Image();
-  ballSize = 100;
-  ballPosition = new DOMPoint(100, 100);
-  ballVelocity = new DOMPoint(10, 10);
+  // Player position and viewing angle
+  player = { x: 3.5, y: 3.5, angle: 0 };
 
-  constructor() {
-    this.ballImage.src = 'ball.png';
+  // Map definition: 8x8 grid with one interior wall
+  readonly mapWidth = 8;
+  readonly mapHeight = 8;
+  readonly map: number[] = [
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 1, 1, 1, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 0, 0, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,
+  ];
+
+  onEnter() {
+    // Reset player when entering game
+    this.player.x = 3.5;
+    this.player.y = 3.5;
+    this.player.angle = 0;
   }
 
-  // Make sure ball starts at the same spot when game is entered
-  onEnter() {
-    this.ballPosition = new DOMPoint(100, 100);
-    this.ballVelocity = new DOMPoint(10, 10);
+  private getMap(x: number, y: number) {
+    if (x < 0 || x >= this.mapWidth || y < 0 || y >= this.mapHeight) {
+      return 1;
+    }
+    return this.map[y * this.mapWidth + x];
   }
 
   onUpdate() {
-    // Update velocity from controller
-    this.ballVelocity.x += controls.inputDirection.x;
-    this.ballVelocity.y += controls.inputDirection.y;
+    const moveSpeed = 0.05;
+    const rotSpeed = 0.03;
 
-    // Check collisions with edges of map
-    if (this.ballPosition.x + this.ballSize > drawEngine.canvasWidth || this.ballPosition.x <= 0) {
-      this.ballVelocity.x *= -1;
+    // Rotation with left/right
+    if (controls.isLeft) this.player.angle -= rotSpeed;
+    if (controls.isRight) this.player.angle += rotSpeed;
+
+    // Movement forward/backward
+    let dir = 0;
+    if (controls.isUp) dir = 1;
+    if (controls.isDown) dir = -1;
+
+    const newX = this.player.x + Math.cos(this.player.angle) * moveSpeed * dir;
+    const newY = this.player.y + Math.sin(this.player.angle) * moveSpeed * dir;
+
+    // Simple collision check
+    if (!this.getMap(Math.floor(newX), Math.floor(this.player.y))) this.player.x = newX;
+    if (!this.getMap(Math.floor(this.player.x), Math.floor(newY))) this.player.y = newY;
+
+    const ctx = drawEngine.context;
+    const w = drawEngine.canvasWidth;
+    const h = drawEngine.canvasHeight;
+
+    // Clear and draw sky & floor
+    ctx.fillStyle = '#87CEEB';
+    ctx.fillRect(0, 0, w, h / 2);
+    ctx.fillStyle = '#444';
+    ctx.fillRect(0, h / 2, w, h / 2);
+
+    // Raycasting for each column
+    const fov = Math.PI / 3; // 60deg FOV
+    for (let x = 0; x < w; x++) {
+      const rayAngle = this.player.angle - fov / 2 + (x / w) * fov;
+      let distance = 0;
+      let hit = false;
+      let rayX = this.player.x;
+      let rayY = this.player.y;
+      const step = 0.02;
+      while (!hit && distance < 16) {
+        rayX += Math.cos(rayAngle) * step;
+        rayY += Math.sin(rayAngle) * step;
+        distance += step;
+        if (this.getMap(Math.floor(rayX), Math.floor(rayY))) {
+          hit = true;
+        }
+      }
+
+      const lineHeight = h / (distance || 1);
+      const start = (h - lineHeight) / 2;
+      ctx.fillStyle = '#888';
+      ctx.fillRect(x, start, 1, lineHeight);
     }
-
-    if (this.ballPosition.y + this.ballSize > drawEngine.canvasHeight || this.ballPosition.y <= 0) {
-      this.ballVelocity.y *= -1;
-    }
-
-    this.ballPosition.x += this.ballVelocity.x;
-    this.ballPosition.y += this.ballVelocity.y;
-
-    // Apply Drag
-    this.ballVelocity.x *= 0.99;
-    this.ballVelocity.y *= 0.99;
-
-    // Clamp top speed
-    this.ballVelocity = clamp(this.ballVelocity, 25);
-
-    drawEngine.context.drawImage(
-      this.ballImage,
-      this.ballPosition.x,
-      this.ballPosition.y,
-      this.ballSize,
-      this.ballSize
-    );
-    renderWebGl(this.ballPosition, this.ballVelocity);
 
     if (controls.isEscape) {
       gameStateMachine.setState(menuState);
@@ -62,3 +98,4 @@ class GameState implements State {
 }
 
 export const gameState = new GameState();
+

--- a/src/game-states/menu.state.ts
+++ b/src/game-states/menu.state.ts
@@ -25,12 +25,12 @@ class MenuState implements State {
       if (this.isStartSelected) {
         gameStateMachine.setState(gameState);
       } else {
-        this.toggleFullscreen();
+        MenuState.toggleFullscreen();
       }
     }
   }
 
-  toggleFullscreen() {
+  static toggleFullscreen() {
     if (!document.fullscreenElement) {
       document.documentElement.requestFullscreen();
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { drawEngine } from './core/draw-engine';
-import { menuState } from './game-states/menu.state';
 import { createGameStateMachine, gameStateMachine } from './game-state-machine';
 import { controls } from '@/core/controls';
 import { gameState } from '@/game-states/game.state';


### PR DESCRIPTION
## Summary
- replace ball game with simple raycast-based FPS
- allow moving and rotating to view a single wall
- clean up fullscreen toggle and unused imports to keep linting green

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f0bb38b608326a410fb38c9bfe74b