### PR TITLE
Improve UI clarity and setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Pet Simulator?</title>
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
     <canvas id="game" width="320" height="180" aria-label="Game Canvas" role="img"></canvas>
-    <script type="module" src="../src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,17 @@ import { CONST } from './util/constants.js';
 // Bootstrap
 const canvas = /** @type {HTMLCanvasElement} */(document.getElementById('game'));
 const renderer = new Renderer(canvas, CONST.WIDTH, CONST.HEIGHT);
+
+function fitCanvas(){
+  const ratio = CONST.WIDTH/CONST.HEIGHT;
+  let w = window.innerWidth;
+  let h = window.innerHeight;
+  if(w/h > ratio){ w = h * ratio; } else { h = w / ratio; }
+  canvas.style.width = w + 'px';
+  canvas.style.height = h + 'px';
+}
+window.addEventListener('resize', fitCanvas);
+fitCanvas();
 const audio = new AudioEngine();
 const effects = new EffectsController(renderer, audio);
 const timers = new Timer();

--- a/src/states/State_BOOT.js
+++ b/src/states/State_BOOT.js
@@ -1,9 +1,9 @@
 /** @module states/State_BOOT */
-import { CONST } from '../util/constants.js';
+import { UI } from '../ui/UI.js';
 export class State_BOOT{
   /** @param {import('../core/Game.js').Game} game */
-  constructor(game){ this.g=game; this.t=0; }
-  enter(){ this.t=0; }
-  update(dt){ this.t+=dt; if(this.t>2){ this.g.goto('WARNING'); } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#AAA'; c.font='10px monospace'; c.fillText('Pet Simulator', 100, 80); c.fillText('© 2025', 128, 95); r.end(); }
+  constructor(game){ this.g=game; this.ui=new UI(game.renderer.ctx); }
+  enter(){}
+  update(dt){ if(this.ui.button(110,100,100,20,'Start')){ this.g.audio.blip(); this.g.goto('WARNING'); } }
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#AAA'; c.font='10px monospace'; c.fillText('Pet Simulator', 100, 60); c.fillText('Feed, Pet and Play to keep it calm.', 40, 80); c.fillText('© 2025', 128, 150); r.end(); }
 }

--- a/src/states/State_BOOT.js
+++ b/src/states/State_BOOT.js
@@ -5,5 +5,5 @@ export class State_BOOT{
   constructor(game){ this.g=game; this.ui=new UI(game.renderer.ctx); }
   enter(){}
   update(dt){ if(this.ui.button(110,100,100,20,'Start')){ this.g.audio.blip(); this.g.goto('WARNING'); } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#AAA'; c.font='10px monospace'; c.fillText('Pet Simulator', 100, 60); c.fillText('Feed, Pet and Play to keep it calm.', 40, 80); c.fillText('© 2025', 128, 150); r.end(); }
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#AAA'; c.font='12px monospace'; c.fillText('Pet Simulator', 90, 60); c.font='10px monospace'; c.fillText('Feed, Pet and Play to keep it calm.', 40, 80); c.fillText('© 2025', 128, 150); r.end(); }
 }

--- a/src/states/State_COLOR_PICKER.js
+++ b/src/states/State_COLOR_PICKER.js
@@ -3,7 +3,7 @@ import { UI } from '../ui/UI.js';
 export class State_COLOR_PICKER{
   constructor(g){ this.g=g; this.ui=new UI(g.renderer.ctx); this.msg='Pick your color'; this.sel=null; }
   update(dt){}
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#EEE'; c.fillText(this.msg, 90, 40);
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#EEE'; c.font='10px monospace'; c.fillText(this.msg, 80, 40);
     const cols=['Red','Green','Blue','Black'];
     cols.forEach((col,i)=>{ if(this.ui.button(40+i*60,80,50,20,col)){ this.sel=col; this.g.storage.set('color',col); this.g.audio.blip(400+i*100,0.05); }});
     if(this.sel){ c.fillStyle='#0F0'; if(this.ui.button(120,120,80,20,'Continue')){ this.g.goto('ROOM'); } }

--- a/src/states/State_COLOR_PICKER.js
+++ b/src/states/State_COLOR_PICKER.js
@@ -1,12 +1,11 @@
 /** @module states/State_COLOR_PICKER */
+import { UI } from '../ui/UI.js';
 export class State_COLOR_PICKER{
-  constructor(g){ this.g=g; this.tries=0; this.msg='Pick your color'; }
+  constructor(g){ this.g=g; this.ui=new UI(g.renderer.ctx); this.msg='Pick your color'; this.sel=null; }
   update(dt){}
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#EEE'; c.fillText(this.msg, 90, 40); const btn=(x,l)=> this._btn(x,80,50,20,l);
-    if(btn(40,'Red')||btn(100,'Green')||btn(160,'Blue')){ this.tries++; if(this.tries<3){ this.msg='Choose Again'; } else { this.msg='YOU HAVE NO CHOICE.'; }
-      this.g.audio.blip(400+this.tries*100,0.05);
-    }
-    if(this.tries>=3){ c.fillStyle='#0F0'; if(this._btn(220,120,80,20,'Continue')){ this.g.storage.set('color','Black'); this.g.goto('ROOM'); } }
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#EEE'; c.fillText(this.msg, 90, 40);
+    const cols=['Red','Green','Blue','Black'];
+    cols.forEach((col,i)=>{ if(this.ui.button(40+i*60,80,50,20,col)){ this.sel=col; this.g.storage.set('color',col); this.g.audio.blip(400+i*100,0.05); }});
+    if(this.sel){ c.fillStyle='#0F0'; if(this.ui.button(120,120,80,20,'Continue')){ this.g.goto('ROOM'); } }
     r.end(); }
-  _btn(x,y,w,h,label){ const c=this.g.renderer.ctx; const mx=this.g.input.mx, my=this.g.input.my; const down=this.g.input.click; const ho=mx>=x&&mx<=x+w&&my>=y&&my<=y+h; c.fillStyle= ho?'#333':'#111'; c.fillRect(x,y,w,h); c.strokeStyle='#700'; c.strokeRect(x+0.5,y+0.5,w-1,h-1); c.fillStyle='#DDD'; c.fillText(label,x+4,y+6); if(ho&&down){ this.g.input.click=false; return true; } return false; }
 }

--- a/src/states/State_GLITCH_FLASH.js
+++ b/src/states/State_GLITCH_FLASH.js
@@ -4,5 +4,5 @@ export class State_GLITCH_FLASH{
   constructor(g){ this.g=g; this.fx=new TextFX(g.renderer.ctx); this.t=0; }
   enter(){ this.t=0; this.g.effects.flash(); this.g.audio.blip(900,0.08); }
   update(dt){ this.t+=dt; this.fx.tick(dt); const m=this.g.effects.mode; if(m==='reduced'){ if(this.t>0.6) this.g.goto('TITLE_B'); } else if(m==='normal'){ if(this.t>0.25) this.g.goto('TITLE_B'); } else { if(this.t>0.9){ this.g.goto('TITLE_B'); } else { this.g.effects.flash(); } } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; this.fx.draw('LET ME OUT', 80, 80, '#F00', 2); r.end(); }
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#600'); const c=r.ctx; this.fx.draw('LET ME OUT', 40, 70, '#FFF', 3); r.end(); }
 }

--- a/src/states/State_ROOM.js
+++ b/src/states/State_ROOM.js
@@ -14,13 +14,16 @@ export class State_ROOM{
   }
   render(){ const r=this.g.renderer; const c=r.ctx; r.begin(); this.room.draw(); this.cat.draw(c); r.vignette(0.7);
     // UI
-    if(this.ui.button(10,4,40,12,'Feed')){ this.cat.feed(); if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
-    if(this.ui.button(60,4,40,12,'Pet')){ this.cat.pet(); if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
-    if(this.ui.button(110,4,40,12,'Toy')){ this.cat.toy(); this.g.audio.blip(700,0.05); }
+    if(this.ui.button(10,4,60,20,'Feed')){ this.cat.feed(); if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
+    if(this.ui.button(80,4,60,20,'Pet')){ this.cat.pet(); if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
+    if(this.ui.button(150,4,60,20,'Toy')){ this.cat.toy(); this.g.audio.blip(700,0.05); }
     // bars
-    this._bar(10,20,'Happy',this.cat.happy); this._bar(10,30,'Full',this.cat.full); this._bar(10,40,'Play',this.cat.play);
+    this._bar(10,34,'Happy',this.cat.happy); this._bar(10,46,'Full',this.cat.full); this._bar(10,58,'Play',this.cat.play);
     // glitch meter
-    this._bar(10,60,'GLITCH',this.glitch, true);
+    this._bar(10,78,'GLITCH',this.glitch, true);
+
+    // instructions
+    c.fillStyle='#BBB'; c.font='10px monospace'; c.fillText('Use buttons to care for your cat.', 10, 170);
 
     if(this.glitch>0.5){ this.fx.draw('WHO IS REAL', 170, 10, '#F33', 1); }
     if(this.glitch>0.7){ this.fx.crawl('LET ME OUT', c.canvas); }
@@ -33,5 +36,5 @@ export class State_ROOM{
   }
   _hot(x,y,w,h){ const i=this.g.input; return i.mx>=x&&i.mx<=x+w&&i.my>=y&&i.my<=y+h; }
   _click(){ if(this.g.input.click){ this.g.input.click=false; return true; } return false; }
-  _bar(x,y,label,val,red=false){ const c=this.g.renderer.ctx; c.fillStyle='#111'; c.fillRect(x,y,80,6); c.fillStyle= red?'#700':'#0A0'; let v=val; if(this.glitch>0.6 && label!=='GLITCH') v = Math.min(1, v+0.01); c.fillRect(x,y,80*v,6); c.fillStyle='#AAA'; c.fillText(label, x+85, y-1); }
+  _bar(x,y,label,val,red=false){ const c=this.g.renderer.ctx; c.fillStyle='#111'; c.fillRect(x,y,80,6); c.fillStyle= red?'#700':'#0A0'; let v=val; if(this.glitch>0.6 && label!=='GLITCH') v = Math.min(1, v+0.01); c.fillRect(x,y,80*v,6); c.fillStyle='#AAA'; c.font='8px monospace'; c.fillText(label, x+85, y-1); }
 }

--- a/src/states/State_ROOM.js
+++ b/src/states/State_ROOM.js
@@ -2,8 +2,9 @@
 import { Room } from '../world/Room.js';
 import { Cat } from '../world/Cat.js';
 import { TextFX } from '../gfx/TextFX.js';
+import { UI } from '../ui/UI.js';
 export class State_ROOM{
-  constructor(g){ this.g=g; this.room=new Room(g.renderer.ctx); this.cat=new Cat(); this.fx=new TextFX(g.renderer.ctx); this.glitch=0; this.petHold=0; this.lastAction=0; }
+  constructor(g){ this.g=g; this.room=new Room(g.renderer.ctx); this.cat=new Cat(); this.fx=new TextFX(g.renderer.ctx); this.ui=new UI(g.renderer.ctx); this.glitch=0; this.petHold=0; this.lastAction=0; }
   enter(){ this.g.audio.grains(); this.g.audio.purr(true); }
   exit(){ this.g.audio.stopBed('grains'); this.g.audio.purr(false); this.g.audio.hum(false); }
   update(dt){ this.g.effects.tick(dt); this.cat.tick(dt); this.fx.tick(dt); this.lastAction+=dt; if(this.g.input.down){ this.petHold+=dt; if(this.petHold>2){ this.glitch = Math.min(1, this.glitch+0.15); this.g.audio.hiss(0.2); this.petHold=0; } } else { this.petHold=0; }
@@ -13,10 +14,9 @@ export class State_ROOM{
   }
   render(){ const r=this.g.renderer; const c=r.ctx; r.begin(); this.room.draw(); this.cat.draw(c); r.vignette(0.7);
     // UI
-    c.fillStyle='#BBB'; c.fillText('Feed', 10, 8); c.fillText('Pet', 60, 8); c.fillText('Toy', 100, 8);
-    if(this._hot(8,6,30,10) && this._click()){ this.cat.feed(); if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
-    if(this._hot(58,6,30,10) && this._click()){ this.cat.pet(); if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
-    if(this._hot(98,6,30,10) && this._click()){ this.cat.toy(); this.g.audio.blip(700,0.05); }
+    if(this.ui.button(10,4,40,12,'Feed')){ this.cat.feed(); if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
+    if(this.ui.button(60,4,40,12,'Pet')){ this.cat.pet(); if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
+    if(this.ui.button(110,4,40,12,'Toy')){ this.cat.toy(); this.g.audio.blip(700,0.05); }
     // bars
     this._bar(10,20,'Happy',this.cat.happy); this._bar(10,30,'Full',this.cat.full); this._bar(10,40,'Play',this.cat.play);
     // glitch meter

--- a/src/states/State_TITLE_A.js
+++ b/src/states/State_TITLE_A.js
@@ -1,7 +1,9 @@
 /** @module states/State_TITLE_A */
+import { Cat } from '../world/Cat.js';
+/** Friendly title screen before things go wrong. Shows pet and waits. */
 export class State_TITLE_A{
-  constructor(g){ this.g=g; this.t=0; }
+  constructor(g){ this.g=g; this.t=0; this.cat=new Cat(); }
   enter(){ this.t=0; }
-  update(dt){ this.t+=dt; if(this.t>1.2){ this.g.goto('GLITCH_FLASH'); } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#FFF'; c.font='12px monospace'; c.fillText('...', 150, 85); r.end(); }
+  update(dt){ this.t+=dt; if(this.t>3){ this.g.goto('GLITCH_FLASH'); } }
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; this.cat.draw(c); c.fillStyle='#FFF'; c.font='14px monospace'; c.fillText('Pet Simulator', 90, 40); r.end(); }
 }

--- a/src/states/State_WARNING.js
+++ b/src/states/State_WARNING.js
@@ -4,14 +4,14 @@ export class State_WARNING{
   constructor(g){ this.g=g; this.ui=new UI(g.renderer.ctx); this.confirmExtreme=false; }
   enter(){ /* show */ }
   update(dt){ this.g.effects.tick(dt); }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#FFF'; c.font='8px monospace'; c.fillText('WARNING: Contains flashing imagery, sudden audio, and unsettling content.', 8, 20); c.fillText('Player discretion advised. Not recommended for photosensitive players.', 8, 30);
+  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#FFF'; c.font='10px monospace'; c.fillText('WARNING: Contains flashing imagery, sudden audio, and unsettling content.', 8, 20); c.fillText('Player discretion advised. Not recommended for photosensitive players.', 8, 32);
     const normal = this.ui.button(20,60,120,20,'Play — Normal');
     const reduced= this.ui.button(20,85,120,20,'Play — Reduced Flashes');
     const extreme= this.ui.button(20,110,120,20,'Play — Extreme Mode');
     if(normal){ this.g.effects.setMode('normal'); this.g.goto('TITLE_A'); }
     if(reduced){ this.g.effects.setMode('reduced'); this.g.goto('TITLE_A'); }
     if(extreme){ this.confirmExtreme=true; }
-    if(this.confirmExtreme){ c.fillStyle='#200'; c.fillRect(10, 50, 300, 80); c.fillStyle='#EEE'; c.fillText('I agree to intense audio/visuals.', 20, 70); if(this.ui.button(20,95,60,16,'Agree')){ this.g.effects.setMode('extreme'); this.g.goto('TITLE_A'); } if(this.ui.button(90,95,60,16,'Cancel')) this.confirmExtreme=false; }
+    if(this.confirmExtreme){ c.fillStyle='#200'; c.fillRect(10, 50, 300, 80); c.fillStyle='#EEE'; c.font='10px monospace'; c.fillText('I agree to intense audio/visuals.', 20, 70); if(this.ui.button(20,95,60,16,'Agree')){ this.g.effects.setMode('extreme'); this.g.goto('TITLE_A'); } if(this.ui.button(90,95,60,16,'Cancel')) this.confirmExtreme=false; }
     // Options: mute/vol
     c.fillStyle='#888'; c.fillText('Mute', 170, 66); if(this.ui.button(200,60,40,16, this.g.audio.muted?'Yes':'No')){ this.g.audio.setMute(!this.g.audio.muted); this.g.audio.ensure(); this.g.audio.blip(); }
     c.fillText('Volume', 170, 90); const v=this.ui.slider(200,90,80,this.g.audio.volume); if(v!==this.g.audio.volume){ this.g.audio.setVolume(v); }

--- a/src/ui/UI.js
+++ b/src/ui/UI.js
@@ -7,7 +7,22 @@ export class UI{
   constructor(ctx){ this.ctx=ctx; this.mx=0; this.my=0; this.down=false; this.clicked=false; this._bind(); }
   _bind(){ const c=this.ctx.canvas; c.addEventListener('mousemove',e=>{const r=c.getBoundingClientRect(); this.mx=(e.clientX-r.left)*(c.width/r.width); this.my=(e.clientY-r.top)*(c.height/r.height);}); c.addEventListener('mousedown',()=>{this.down=true;}); c.addEventListener('mouseup',()=>{this.down=false; this.clicked=true; setTimeout(()=>this.clicked=false,0);}); }
   /** @param {number} x @param {number} y @param {number} w @param {number} h @param {string} label */
-  button(x,y,w,h,label){ const ho=this.mx>=x&&this.mx<=x+w&&this.my>=y&&this.my<=y+h; const c=this.ctx; c.save(); c.fillStyle= ho? '#333':'#111'; c.fillRect(x,y,w,h); c.strokeStyle='#900'; c.strokeRect(x+0.5,y+0.5,w-1,h-1); c.fillStyle='#DDD'; c.font='8px monospace'; c.textBaseline='middle'; c.fillText(label, x+4, y+h/2); c.restore(); if(ho && this.clicked){ this.clicked=false; return true; } return false; }
+  button(x,y,w,h,label){
+    const ho=this.mx>=x&&this.mx<=x+w&&this.my>=y&&this.my<=y+h;
+    const c=this.ctx; c.save();
+    c.fillStyle = ho ? (this.down? '#555':'#333') : '#111';
+    c.fillRect(x,y,w,h);
+    c.strokeStyle='#FFF';
+    c.strokeRect(x+0.5,y+0.5,w-1,h-1);
+    c.fillStyle='#DDD';
+    c.font='8px monospace';
+    c.textBaseline='middle';
+    c.textAlign='center';
+    c.fillText(label, x+w/2, y+h/2);
+    c.restore();
+    if(ho && this.clicked){ this.clicked=false; return true; }
+    return false;
+  }
   /** Volume slider 0..1 */
   slider(x,y,w,val){ const c=this.ctx; c.save(); c.fillStyle='#111'; c.fillRect(x,y,w,6); c.fillStyle='#A00'; c.fillRect(x,y,w*val,6); c.restore(); const ho=this.mx>=x&&this.mx<=x+w&&this.my>=y&&this.my<=y+6; if(ho&&this.down){ return Math.max(0,Math.min(1,(this.mx-x)/w)); } return val; }
 }

--- a/src/ui/UI.js
+++ b/src/ui/UI.js
@@ -15,7 +15,7 @@ export class UI{
     c.strokeStyle='#FFF';
     c.strokeRect(x+0.5,y+0.5,w-1,h-1);
     c.fillStyle='#DDD';
-    c.font='8px monospace';
+    c.font='10px monospace';
     c.textBaseline='middle';
     c.textAlign='center';
     c.fillText(label, x+w/2, y+h/2);

--- a/src/world/Cat.js
+++ b/src/world/Cat.js
@@ -2,8 +2,9 @@
  * @module world/Cat
  * Simple black cat sprite and basic needs; responds to pet/feed/toy.
  */
+import { CONST } from '../util/constants.js';
 export class Cat{
-  constructor(){ this.x=100; this.y=110; this.happy=0.5; this.full=0.5; this.play=0.5; this.lookAt=false; this.purr=false; }
+  constructor(){ this.x=(CONST.WIDTH-20)/2; this.y=(CONST.HEIGHT/2)+10; this.happy=0.5; this.full=0.5; this.play=0.5; this.lookAt=false; this.purr=false; }
   tick(dt){ this.happy = Math.max(0,Math.min(1,this.happy - dt*0.01)); this.full = Math.max(0,Math.min(1,this.full - dt*0.02)); this.play = Math.max(0,Math.min(1,this.play - dt*0.015)); }
   draw(ctx){ ctx.save(); ctx.fillStyle='#000'; // body
     ctx.fillRect(this.x, this.y-8, 20, 10); // body

--- a/style.css
+++ b/style.css
@@ -12,4 +12,5 @@ body {
   outline: none;
   cursor: crosshair;
   background: #000;
+  image-rendering: pixelated;
 }

--- a/style.css
+++ b/style.css
@@ -2,9 +2,14 @@
 :root { color-scheme: dark; }
 * { box-sizing: border-box; }
 html, body { height: 100%; margin: 0; background: #000; }
-body { display: grid; place-items: center; }
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
 #game {
-  image-rendering: pixelated; /* nearest-neighbor upscale */
-  outline: none; cursor: crosshair;
+  outline: none;
+  cursor: crosshair;
   background: #000;
 }


### PR DESCRIPTION
## Summary
- make canvas scale to full screen while keeping aspect
- add a start screen and center the cat
- refresh button and color picker UI with better interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddfcbfb0083268434f39f59790ea5