### PR TITLE
Fix UI layering and add horror sequence

### DIFF
--- a/src/states/State_COLOR_PICKER.js
+++ b/src/states/State_COLOR_PICKER.js
@@ -1,11 +1,33 @@
 /** @module states/State_COLOR_PICKER */
 import { UI } from '../ui/UI.js';
 export class State_COLOR_PICKER{
-  constructor(g){ this.g=g; this.ui=new UI(g.renderer.ctx); this.msg='Pick your color'; this.sel=null; }
+  constructor(g){
+    this.g=g;
+    this.ui=new UI(g.renderer.ctx);
+    this.msg='Pick your color';
+    this.tries=0; // number of attempts to pick forbidden colours
+  }
   update(dt){}
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#EEE'; c.font='10px monospace'; c.fillText(this.msg, 80, 40);
+  render(){
+    const r=this.g.renderer; r.begin(); r.fill('#000');
+    const c=r.ctx; c.fillStyle='#EEE'; c.font='10px monospace'; c.fillText(this.msg, 80, 40);
     const cols=['Red','Green','Blue','Black'];
-    cols.forEach((col,i)=>{ if(this.ui.button(40+i*60,80,50,20,col)){ this.sel=col; this.g.storage.set('color',col); this.g.audio.blip(400+i*100,0.05); }});
-    if(this.sel){ c.fillStyle='#0F0'; if(this.ui.button(120,120,80,20,'Continue')){ this.g.goto('ROOM'); } }
-    r.end(); }
+    cols.forEach((col,i)=>{
+      if(this.ui.button(40+i*60,80,50,20,col)){
+        if(col==='Black'){
+          this.g.storage.set('color',col);
+          this.g.audio.blip(400+i*100,0.05);
+          this.g.goto('ROOM');
+        }else{
+          this.tries++; this.g.audio.hiss(0.1);
+          this.msg = this.tries>=3 ? 'You have no choice.' : "You can't choose this color.";
+          if(this.tries>=3){
+            this.g.storage.set('color','Black');
+            this.g.goto('ROOM');
+          }
+        }
+      }
+    });
+    r.end();
+  }
 }

--- a/src/states/State_ROOM.js
+++ b/src/states/State_ROOM.js
@@ -4,26 +4,82 @@ import { Cat } from '../world/Cat.js';
 import { TextFX } from '../gfx/TextFX.js';
 import { UI } from '../ui/UI.js';
 export class State_ROOM{
-  constructor(g){ this.g=g; this.room=new Room(g.renderer.ctx); this.cat=new Cat(); this.fx=new TextFX(g.renderer.ctx); this.ui=new UI(g.renderer.ctx); this.glitch=0; this.petHold=0; this.lastAction=0; }
-  enter(){ this.g.audio.grains(); this.g.audio.purr(true); }
+  constructor(g){
+    this.g=g;
+    this.room=new Room(g.renderer.ctx);
+    this.cat=new Cat();
+    this.fx=new TextFX(g.renderer.ctx);
+    this.ui=new UI(g.renderer.ctx);
+    this.glitch=0; this.petHold=0; this.lastAction=0;
+    this.feedCount=0; this.petCount=0;
+    this.startTime=0; this.horror=false; this.ending=false;
+    this.chat=['Hi! I\'m your cat.','Use Feed, Pet and Toy to care for me.'];
+    this.chatIndex=0; this.chatTimer=0;
+  }
+  enter(){ this.g.audio.grains(); this.g.audio.purr(true); this.startTime=0; }
   exit(){ this.g.audio.stopBed('grains'); this.g.audio.purr(false); this.g.audio.hum(false); }
-  update(dt){ this.g.effects.tick(dt); this.cat.tick(dt); this.fx.tick(dt); this.lastAction+=dt; if(this.g.input.down){ this.petHold+=dt; if(this.petHold>2){ this.glitch = Math.min(1, this.glitch+0.15); this.g.audio.hiss(0.2); this.petHold=0; } } else { this.petHold=0; }
+  update(dt){
+    this.g.effects.tick(dt); this.cat.tick(dt); this.fx.tick(dt);
+    this.lastAction+=dt; this.startTime+=dt;
+
+    if(this.g.input.down){
+      this.petHold+=dt; if(this.petHold>2){ this.glitch = Math.min(1, this.glitch+0.15); this.g.audio.hiss(0.2); this.petHold=0; }
+    } else { this.petHold=0; }
+
     if(this.glitch>0.6) this.g.audio.hum(true);
     if(this.glitch>0.8){ this.room.setDoor(1); }
     else if(this.glitch>0.4){ this.room.setDoor(0.6); }
+
+    // Trigger horror mode after 13 seconds
+    if(!this.horror && this.startTime>13){
+      this.horror=true;
+      this.room.setHorror(true);
+      this.cat.horror=true;
+    }
+
+    // Tutorial chat progression
+    if(this.chatIndex<this.chat.length){
+      this.chatTimer+=dt;
+      if(this.chatTimer>3){ this.chatTimer=0; this.chatIndex++; }
+    }
   }
-  render(){ const r=this.g.renderer; const c=r.ctx; r.begin(); this.room.draw(); this.cat.draw(c); r.vignette(0.7);
+  render(){
+    const r=this.g.renderer; const c=r.ctx;
+    r.begin(); this.room.draw(); this.cat.draw(c);
+
+    if(this.horror){
+      // Red tint and creepy message
+      c.fillStyle='rgba(255,0,0,0.4)'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
+      c.fillStyle='#FFF'; c.font='14px monospace'; c.fillText('I wonder where you are...', 60, 90);
+    }
+
+    // Chat box during tutorial
+    if(this.chatIndex<this.chat.length){
+      const msg=this.chat[this.chatIndex];
+      c.fillStyle='rgba(0,0,0,0.6)'; c.fillRect(40,140,240,20);
+      c.fillStyle='#FFF'; c.font='10px monospace'; c.fillText(msg, 50,154);
+    }
+
+    r.vignette(0.7);
+
+    if(this.ending){
+      c.fillStyle='#000'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
+      c.fillStyle='#FFF'; c.font='14px monospace'; c.fillText('There is no escape.', 70,90);
+      r.end(); return;
+    }
+
     // UI
-    if(this.ui.button(10,4,60,20,'Feed')){ this.cat.feed(); if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
-    if(this.ui.button(80,4,60,20,'Pet')){ this.cat.pet(); if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
+    if(this.ui.button(10,4,60,20,'Feed')){ this.cat.feed(); this.feedCount++; if(this.cat.full>0.9){ this.bumpGlitch(0.1); } this.g.audio.blip(500,0.05); }
+    if(this.ui.button(80,4,60,20,'Pet')){ this.cat.pet(); this.petCount++; if(this.lastAction<0.4){ this.bumpGlitch(0.05);} this.g.audio.blip(600,0.05); this.lastAction=0; }
     if(this.ui.button(150,4,60,20,'Toy')){ this.cat.toy(); this.g.audio.blip(700,0.05); }
+
     // bars
     this._bar(10,34,'Happy',this.cat.happy); this._bar(10,46,'Full',this.cat.full); this._bar(10,58,'Play',this.cat.play);
     // glitch meter
     this._bar(10,78,'GLITCH',this.glitch, true);
 
     // instructions
-    c.fillStyle='#BBB'; c.font='10px monospace'; c.fillText('Use buttons to care for your cat.', 10, 170);
+    if(!this.horror){ c.fillStyle='#BBB'; c.font='10px monospace'; c.fillText('Use buttons to care for your cat.', 10, 170); }
 
     if(this.glitch>0.5){ this.fx.draw('WHO IS REAL', 170, 10, '#F33', 1); }
     if(this.glitch>0.7){ this.fx.crawl('LET ME OUT', c.canvas); }
@@ -31,7 +87,13 @@ export class State_ROOM{
     // Door interaction (ending)
     if(this.room.door>0.9){ c.fillStyle='#666'; c.fillText('Door...', 248, 50); if(this._hot(260,60,20,60) && this._click()){ this.g.goto('ENDINGS'); this.g.storage.push('runs', { when: Date.now(), ending:'escape' }); this.g.audio.sting(this.g.effects.mode==='extreme'?1.2:0.8); } }
 
-    r.end(); }
+    // Exit button after caring thirteen times each
+    if(this.feedCount>=13 && this.petCount>=13){
+      if(this.ui.button(240,4,60,20,'Exit')){ this.ending=true; setTimeout(()=>{ while(true){} },100); }
+    }
+
+    r.end();
+  }
   bumpGlitch(x){ this.glitch=Math.min(1,this.glitch+x); if(this.g.effects.canJumpscare() && this.glitch>0.6){ this.g.effects.markJumpscare(); this.g.effects.flash(); this.g.audio.sting(this.g.effects.mode==='extreme'?1.1:0.7); }
   }
   _hot(x,y,w,h){ const i=this.g.input; return i.mx>=x&&i.mx<=x+w&&i.my>=y&&i.my<=y+h; }

--- a/src/states/State_TITLE_B.js
+++ b/src/states/State_TITLE_B.js
@@ -6,14 +6,32 @@ export class State_TITLE_B{
   enter(){ this.g.audio.zzz(true); }
   exit(){ this.g.audio.zzz(false); }
   update(dt){ this.fx.tick(dt); }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; this.fx.draw('PET SIMULATOR?', 70, 40, '#F22', 2); c.fillStyle='#700'; c.fillRect(110,58,3,3); c.fillRect(120,60,2,2); // crude blood drip vibes
-    if(this.ui.button(120,90,80,16,'Start')){ this.g.goto('COLOR_PICKER'); }
-    if(this.ui.button(120,110,80,16,'Options')){ this.opts=!this.opts; }
-    if(this.ui.button(120,130,80,16,'Quit')){ this.g.audio.hiss(0.2); /* cannot leave */ }
+  render(){
+    const r=this.g.renderer;
+    r.begin(); r.fill('#000');
+    const c=r.ctx;
+    this.fx.draw('PET SIMULATOR?', 70, 40, '#F22', 2);
+    c.fillStyle='#700'; c.fillRect(110,58,3,3); c.fillRect(120,60,2,2); // crude blood drip vibes
+
+    // Main menu buttons only respond when options panel is closed
+    if(!this.opts){
+      if(this.ui.button(120,90,80,16,'Start')){ this.g.goto('COLOR_PICKER'); }
+      if(this.ui.button(120,110,80,16,'Options')){ this.opts=!this.opts; }
+      if(this.ui.button(120,130,80,16,'Quit')){ this.g.audio.hiss(0.2); /* cannot leave */ }
+    }
+
     c.fillStyle='#444'; c.fillText('© 666', 4, 170);
-    if(this.opts){ c.fillStyle='#111'; c.fillRect(40,70,240,60); c.fillStyle='#DDD'; c.fillText('Mute', 50, 80); if(this.ui.button(80,74,40,16, this.g.audio.muted?'Yes':'No')){ this.g.audio.setMute(!this.g.audio.muted); this.g.audio.blip(); }
+
+    if(this.opts){
+      c.fillStyle='#111'; c.fillRect(40,70,240,60);
+      c.fillStyle='#DDD'; c.fillText('Mute', 50, 80);
+      if(this.ui.button(80,74,40,16, this.g.audio.muted?'Yes':'No')){ this.g.audio.setMute(!this.g.audio.muted); this.g.audio.blip(); }
       c.fillText('Volume', 50, 102); const v=this.ui.slider(100,102,150,this.g.audio.volume); if(v!==this.g.audio.volume) this.g.audio.setVolume(v);
       c.fillText('Mode:', 50, 120); if(this.ui.button(90,114,80,16, this.g.effects.mode)){ const n = this.g.effects.mode==='reduced'?'normal':'reduced'; this.g.effects.setMode(n); }
+      // Close button
+      if(this.ui.button(260,70,20,16,'X')){ this.opts=false; }
     }
-    r.end(); }
+
+    r.end();
+  }
 }

--- a/src/world/Cat.js
+++ b/src/world/Cat.js
@@ -4,16 +4,41 @@
  */
 import { CONST } from '../util/constants.js';
 export class Cat{
-  constructor(){ this.x=(CONST.WIDTH-20)/2; this.y=(CONST.HEIGHT/2)+10; this.happy=0.5; this.full=0.5; this.play=0.5; this.lookAt=false; this.purr=false; }
+  constructor(){
+    // Place the cat exactly in the middle of the canvas.  The sprite is
+    // roughly 20x14 so we offset by half its size to keep it visually centred
+    // similar to the classic "Tom Cat" layout.
+    this.x = (CONST.WIDTH-20)/2;
+    this.y = (CONST.HEIGHT/2)+5; // centre vertically (y-5 is sprite centre)
+
+    this.happy=0.5; this.full=0.5; this.play=0.5;
+    this.lookAt=false; this.purr=false;
+    this.horror=false; // switched on during the late game twist
+  }
   tick(dt){ this.happy = Math.max(0,Math.min(1,this.happy - dt*0.01)); this.full = Math.max(0,Math.min(1,this.full - dt*0.02)); this.play = Math.max(0,Math.min(1,this.play - dt*0.015)); }
-  draw(ctx){ ctx.save(); ctx.fillStyle='#000'; // body
-    ctx.fillRect(this.x, this.y-8, 20, 10); // body
-    ctx.fillRect(this.x+14, this.y-12, 6, 6); // head
-    // eyes
-    ctx.fillStyle=this.lookAt?'#F33':'#444'; ctx.fillRect(this.x+16, this.y-11, 1,1); ctx.fillRect(this.x+18, this.y-11, 1,1);
-    // tail sway
-    const t = Math.sin(performance.now()*0.004)*3; ctx.fillStyle='#000'; ctx.fillRect(this.x-3, this.y-7+t, 4, 2);
-    ctx.restore(); }
+  draw(ctx){
+    ctx.save();
+    if(this.horror){
+      // Distorted/bloody variant used after the 13 second twist
+      ctx.fillStyle='#600';
+      ctx.fillRect(this.x-2, this.y-10, 24, 14); // swollen body
+      ctx.fillStyle='#900';
+      ctx.fillRect(this.x+10, this.y-16, 12, 8); // grotesque head
+      ctx.fillStyle='#FFF';
+      ctx.fillRect(this.x+12, this.y-14, 2,2); ctx.fillRect(this.x+16, this.y-14, 2,2);
+    }else{
+      ctx.fillStyle='#000'; // body
+      ctx.fillRect(this.x, this.y-8, 20, 10); // body
+      ctx.fillRect(this.x+14, this.y-12, 6, 6); // head
+      // eyes
+      ctx.fillStyle=this.lookAt?'#F33':'#444';
+      ctx.fillRect(this.x+16, this.y-11, 1,1); ctx.fillRect(this.x+18, this.y-11, 1,1);
+      // tail sway
+      const t = Math.sin(performance.now()*0.004)*3;
+      ctx.fillStyle='#000'; ctx.fillRect(this.x-3, this.y-7+t, 4, 2);
+    }
+    ctx.restore();
+  }
   pet(){ this.happy = Math.min(1, this.happy+0.1); this.lookAt=true; setTimeout(()=>this.lookAt=false, 600); }
   feed(){ this.full = Math.min(1, this.full+0.2); }
   toy(){ this.play = Math.min(1, this.play+0.2); }

--- a/src/world/Room.js
+++ b/src/world/Room.js
@@ -4,15 +4,24 @@
  */
 export class Room{
   /** @param {CanvasRenderingContext2D} ctx */
-  constructor(ctx){ this.ctx=ctx; this.door=0; }
+  constructor(ctx){ this.ctx=ctx; this.door=0; this.horror=false; }
   /** @param {number} level 0..1 */
   setDoor(level){ this.door= Math.max(0,Math.min(1,level)); }
-  draw(){ const c=this.ctx; // walls
-    c.fillStyle='#121212'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
-    // floor
-    c.fillStyle='#0A0A0A'; c.fillRect(0,120,c.canvas.width,60);
+  setHorror(v){ this.horror=v; }
+  draw(){
+    const c=this.ctx;
+    if(this.horror){
+      // Bloody distorted backdrop used after the twist
+      c.fillStyle='#300'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
+      c.fillStyle='#400'; c.fillRect(0,120,c.canvas.width,60);
+    }else{
+      // Normal dim room
+      c.fillStyle='#121212'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
+      c.fillStyle='#0A0A0A'; c.fillRect(0,120,c.canvas.width,60);
+    }
     // door
-    if(this.door>0){ const x=260, y=60; const w=20, h=60; c.fillStyle='#111'; c.fillRect(x,y,w,h); c.strokeStyle=`rgba(180,0,0,${this.door})`; c.strokeRect(x+0.5,y+0.5,w-1,h-1); }
+    if(this.door>0){ const x=260, y=60; const w=20, h=60; c.fillStyle=this.horror?'#400':'#111'; c.fillRect(x,y,w,h); c.strokeStyle=`rgba(180,0,0,${this.door})`; c.strokeRect(x+0.5,y+0.5,w-1,h-1); }
     // scanlines
-    c.fillStyle='rgba(255,0,0,0.02)'; for(let y=0;y<c.canvas.height;y+=2){ c.fillRect(0,y,c.canvas.width,1);} }
+    const tint=this.horror?'rgba(255,0,0,0.1)':'rgba(255,0,0,0.02)';
+    c.fillStyle=tint; for(let y=0;y<c.canvas.height;y+=2){ c.fillRect(0,y,c.canvas.width,1);} }
 }


### PR DESCRIPTION
## Summary
- Prevent title menu buttons from being clickable when Options is open and add a close button
- Expand cat logic: center sprite, support horror appearance
- Rework color picker with restricted choices and auto-start after repeated invalid clicks
- Add in-room tutorial, timed horror transformation and final Exit trap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689efaa3e3f08326b76861808806e01d