### PR TITLE
Refine intro flow and enlarge cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Open `/index.html` in a modern browser. No build tools needed.
 - `/src/audio/*` – Web Audio synth engine + master Limiter.
 - `/src/ui/UI.js` – Minimal canvas UI.
 - `/src/world/*` – Room and Cat.
-- `/src/states/*` – BOOT → WARNING → TITLE_A → GLITCH_FLASH → TITLE_B → COLOR_PICKER → ROOM → EVENTS/LORE → ENDINGS.
+- `/src/states/*` – BOOT → WARNING → TITLE_A → TITLE_B → COLOR_PICKER → ROOM → EVENTS/LORE → ENDINGS.
 - `/src/util/*` – input, constants, storage.
 
 ## Safety Caps & Modes
@@ -27,6 +27,6 @@ Audio: Master gain ≤ 0.6, master limiter engaged. Mute/Volume available on WAR
 Implemented in `AudioEngine.zzz()`. It’s a filtered-noise loop with light waveshaping. It ducks naturally because UI blips are short and the bed is low gain. Starts on TITLE_B enter, stops on exit.
 
 ## Notes
-- Color picker forces Black after 3 "Choose Again" prompts ("YOU HAVE NO CHOICE.") then proceeds.
+- Color picker flashes a full red screen after three failed picks before forcing Black and proceeding.
 - Room has escalating glitch meter, door emergence, at least two endings (escape vs. other text variant).
 - LocalStorage: seed and run history stored under `pps_*` keys.

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -6,7 +6,6 @@
 import { State_BOOT } from '../states/State_BOOT.js';
 import { State_WARNING } from '../states/State_WARNING.js';
 import { State_TITLE_A } from '../states/State_TITLE_A.js';
-import { State_GLITCH_FLASH } from '../states/State_GLITCH_FLASH.js';
 import { State_TITLE_B } from '../states/State_TITLE_B.js';
 import { State_COLOR_PICKER } from '../states/State_COLOR_PICKER.js';
 import { State_ROOM } from '../states/State_ROOM.js';
@@ -43,7 +42,6 @@ export class Game {
       BOOT: new State_BOOT(this),
       WARNING: new State_WARNING(this),
       TITLE_A: new State_TITLE_A(this),
-      GLITCH_FLASH: new State_GLITCH_FLASH(this),
       TITLE_B: new State_TITLE_B(this),
       COLOR_PICKER: new State_COLOR_PICKER(this),
       ROOM: new State_ROOM(this),

--- a/src/states/State_BOOT.js
+++ b/src/states/State_BOOT.js
@@ -1,9 +1,18 @@
 /** @module states/State_BOOT */
-import { UI } from '../ui/UI.js';
+/**
+ * Initial splash screen.  Shows a short instructional message for a brief
+ * moment before continuing into the warning screen.  There is no user input
+ * here; the message simply fades after one second.
+ */
 export class State_BOOT{
   /** @param {import('../core/Game.js').Game} game */
-  constructor(game){ this.g=game; this.ui=new UI(game.renderer.ctx); }
-  enter(){}
-  update(dt){ if(this.ui.button(110,100,100,20,'Start')){ this.g.audio.blip(); this.g.goto('WARNING'); } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; c.fillStyle='#AAA'; c.font='12px monospace'; c.fillText('Pet Simulator', 90, 60); c.font='10px monospace'; c.fillText('Feed, Pet and Play to keep it calm.', 40, 80); c.fillText('© 2025', 128, 150); r.end(); }
+  constructor(game){ this.g=game; this.t=0; }
+  enter(){ this.t=0; }
+  update(dt){ this.t+=dt; if(this.t>1){ this.g.goto('WARNING'); } }
+  render(){
+    const r=this.g.renderer; r.begin(); r.fill('#CDE');
+    const c=r.ctx; c.fillStyle='#000'; c.font='12px monospace';
+    c.fillText('Feed, Pet and Play to keep it calm.', 20, 90);
+    r.end();
+  }
 }

--- a/src/states/State_COLOR_PICKER.js
+++ b/src/states/State_COLOR_PICKER.js
@@ -6,10 +6,26 @@ export class State_COLOR_PICKER{
     this.ui=new UI(g.renderer.ctx);
     this.msg='Pick your color';
     this.tries=0; // number of attempts to pick forbidden colours
+    this.noChoice=false; this.noChoiceTimer=0; // red-screen takeover
   }
-  update(dt){}
+  update(dt){
+    if(this.noChoice){
+      this.noChoiceTimer+=dt;
+      if(this.noChoiceTimer>1){
+        this.g.storage.set('color','Black');
+        this.g.goto('ROOM');
+      }
+    }
+  }
   render(){
-    const r=this.g.renderer; r.begin(); r.fill('#000');
+    const r=this.g.renderer; r.begin();
+    if(this.noChoice){
+      r.fill('#F00');
+      const c=r.ctx; c.fillStyle='#000'; c.font='16px monospace';
+      c.fillText('YOU GOT NO CHOICE', 40, 90);
+      r.end(); return;
+    }
+    r.fill('#000');
     const c=r.ctx; c.fillStyle='#EEE'; c.font='10px monospace'; c.fillText(this.msg, 80, 40);
     const cols=['Red','Green','Blue','Black'];
     cols.forEach((col,i)=>{
@@ -20,11 +36,8 @@ export class State_COLOR_PICKER{
           this.g.goto('ROOM');
         }else{
           this.tries++; this.g.audio.hiss(0.1);
-          this.msg = this.tries>=3 ? 'You have no choice.' : "You can't choose this color.";
-          if(this.tries>=3){
-            this.g.storage.set('color','Black');
-            this.g.goto('ROOM');
-          }
+          this.msg = "You can't choose this color.";
+          if(this.tries>=3){ this.noChoice=true; this.noChoiceTimer=0; }
         }
       }
     });

--- a/src/states/State_GLITCH_FLASH.js
+++ b/src/states/State_GLITCH_FLASH.js
@@ -1,8 +1,0 @@
-/** @module states/State_GLITCH_FLASH */
-import { TextFX } from '../gfx/TextFX.js';
-export class State_GLITCH_FLASH{
-  constructor(g){ this.g=g; this.fx=new TextFX(g.renderer.ctx); this.t=0; }
-  enter(){ this.t=0; this.g.effects.flash(); this.g.audio.blip(900,0.08); }
-  update(dt){ this.t+=dt; this.fx.tick(dt); const m=this.g.effects.mode; if(m==='reduced'){ if(this.t>0.6) this.g.goto('TITLE_B'); } else if(m==='normal'){ if(this.t>0.25) this.g.goto('TITLE_B'); } else { if(this.t>0.9){ this.g.goto('TITLE_B'); } else { this.g.effects.flash(); } } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#600'); const c=r.ctx; this.fx.draw('LET ME OUT', 40, 70, '#FFF', 3); r.end(); }
-}

--- a/src/states/State_ROOM.js
+++ b/src/states/State_ROOM.js
@@ -13,8 +13,8 @@ export class State_ROOM{
     this.glitch=0; this.petHold=0; this.lastAction=0;
     this.feedCount=0; this.petCount=0;
     this.startTime=0; this.horror=false; this.ending=false;
-    this.chat=['Hi! I\'m your cat.','Use Feed, Pet and Toy to care for me.'];
-    this.chatIndex=0; this.chatTimer=0;
+    this.chat=['Feed pet and play to keep it calm.'];
+    this.chatIndex=0; this.chatTimer=0; this.chatDur=1;
   }
   enter(){ this.g.audio.grains(); this.g.audio.purr(true); this.startTime=0; }
   exit(){ this.g.audio.stopBed('grains'); this.g.audio.purr(false); this.g.audio.hum(false); }
@@ -40,7 +40,7 @@ export class State_ROOM{
     // Tutorial chat progression
     if(this.chatIndex<this.chat.length){
       this.chatTimer+=dt;
-      if(this.chatTimer>3){ this.chatTimer=0; this.chatIndex++; }
+      if(this.chatTimer>this.chatDur){ this.chatIndex++; }
     }
   }
   render(){
@@ -60,7 +60,7 @@ export class State_ROOM{
       c.fillStyle='#FFF'; c.font='10px monospace'; c.fillText(msg, 50,154);
     }
 
-    r.vignette(0.7);
+    r.vignette(this.horror?0.7:0.3);
 
     if(this.ending){
       c.fillStyle='#000'; c.fillRect(0,0,c.canvas.width,c.canvas.height);

--- a/src/states/State_TITLE_A.js
+++ b/src/states/State_TITLE_A.js
@@ -4,6 +4,12 @@ import { Cat } from '../world/Cat.js';
 export class State_TITLE_A{
   constructor(g){ this.g=g; this.t=0; this.cat=new Cat(); }
   enter(){ this.t=0; }
-  update(dt){ this.t+=dt; if(this.t>3){ this.g.goto('GLITCH_FLASH'); } }
-  render(){ const r=this.g.renderer; r.begin(); r.fill('#000'); const c=r.ctx; this.cat.draw(c); c.fillStyle='#FFF'; c.font='14px monospace'; c.fillText('Pet Simulator', 90, 40); r.end(); }
+  update(dt){ this.t+=dt; if(this.t>2){ this.g.goto('TITLE_B'); } }
+  render(){
+    const r=this.g.renderer; r.begin(); r.fill('#CDE');
+    const c=r.ctx; this.cat.draw(c);
+    c.fillStyle='#000'; c.font='14px monospace';
+    c.fillText('Pet Simulator', 80, 40);
+    r.end();
+  }
 }

--- a/src/world/Cat.js
+++ b/src/world/Cat.js
@@ -5,11 +5,10 @@
 import { CONST } from '../util/constants.js';
 export class Cat{
   constructor(){
-    // Place the cat exactly in the middle of the canvas.  The sprite is
-    // roughly 20x14 so we offset by half its size to keep it visually centred
-    // similar to the classic "Tom Cat" layout.
-    this.x = (CONST.WIDTH-20)/2;
-    this.y = (CONST.HEIGHT/2)+5; // centre vertically (y-5 is sprite centre)
+    // Place the cat roughly in the middle of the canvas.  The new sprite is
+    // much larger (~40x28) so the offsets are adjusted to keep it centred.
+    this.x = (CONST.WIDTH-40)/2;
+    this.y = (CONST.HEIGHT/2)+10; // centre vertically
 
     this.happy=0.5; this.full=0.5; this.play=0.5;
     this.lookAt=false; this.purr=false;
@@ -21,21 +20,21 @@ export class Cat{
     if(this.horror){
       // Distorted/bloody variant used after the 13 second twist
       ctx.fillStyle='#600';
-      ctx.fillRect(this.x-2, this.y-10, 24, 14); // swollen body
+      ctx.fillRect(this.x-4, this.y-20, 48, 28); // swollen body
       ctx.fillStyle='#900';
-      ctx.fillRect(this.x+10, this.y-16, 12, 8); // grotesque head
+      ctx.fillRect(this.x+20, this.y-32, 20, 16); // grotesque head
       ctx.fillStyle='#FFF';
-      ctx.fillRect(this.x+12, this.y-14, 2,2); ctx.fillRect(this.x+16, this.y-14, 2,2);
+      ctx.fillRect(this.x+24, this.y-28, 4,4); ctx.fillRect(this.x+32, this.y-28, 4,4);
     }else{
       ctx.fillStyle='#000'; // body
-      ctx.fillRect(this.x, this.y-8, 20, 10); // body
-      ctx.fillRect(this.x+14, this.y-12, 6, 6); // head
+      ctx.fillRect(this.x, this.y-16, 40, 20); // body
+      ctx.fillRect(this.x+28, this.y-32, 12, 12); // head
       // eyes
       ctx.fillStyle=this.lookAt?'#F33':'#444';
-      ctx.fillRect(this.x+16, this.y-11, 1,1); ctx.fillRect(this.x+18, this.y-11, 1,1);
+      ctx.fillRect(this.x+32, this.y-28, 3,3); ctx.fillRect(this.x+36, this.y-28, 3,3);
       // tail sway
-      const t = Math.sin(performance.now()*0.004)*3;
-      ctx.fillStyle='#000'; ctx.fillRect(this.x-3, this.y-7+t, 4, 2);
+      const t = Math.sin(performance.now()*0.004)*5;
+      ctx.fillStyle='#000'; ctx.fillRect(this.x-6, this.y-14+t, 6, 4);
     }
     ctx.restore();
   }

--- a/src/world/Room.js
+++ b/src/world/Room.js
@@ -15,12 +15,12 @@ export class Room{
       c.fillStyle='#300'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
       c.fillStyle='#400'; c.fillRect(0,120,c.canvas.width,60);
     }else{
-      // Normal dim room
-      c.fillStyle='#121212'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
-      c.fillStyle='#0A0A0A'; c.fillRect(0,120,c.canvas.width,60);
+      // Friendly brightly lit room for the first 13 seconds
+      c.fillStyle='#CDE'; c.fillRect(0,0,c.canvas.width,c.canvas.height);
+      c.fillStyle='#EEE'; c.fillRect(0,120,c.canvas.width,60);
     }
     // door
-    if(this.door>0){ const x=260, y=60; const w=20, h=60; c.fillStyle=this.horror?'#400':'#111'; c.fillRect(x,y,w,h); c.strokeStyle=`rgba(180,0,0,${this.door})`; c.strokeRect(x+0.5,y+0.5,w-1,h-1); }
+    if(this.door>0){ const x=260, y=60; const w=20, h=60; c.fillStyle=this.horror?'#400':'#654321'; c.fillRect(x,y,w,h); c.strokeStyle=`rgba(180,0,0,${this.door})`; c.strokeRect(x+0.5,y+0.5,w-1,h-1); }
     // scanlines
     const tint=this.horror?'rgba(255,0,0,0.1)':'rgba(255,0,0,0.02)';
     c.fillStyle=tint; for(let y=0;y<c.canvas.height;y+=2){ c.fillRect(0,y,c.canvas.width,1);} }


### PR DESCRIPTION
## Summary
- Show quick instructional splash screen before warnings
- Start with a friendly title that turns dark after two seconds
- Enforce choosing black via full-screen red warning and redesign the cat and room

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/states/State_BOOT.js src/states/State_TITLE_A.js src/states/State_COLOR_PICKER.js src/core/Game.js src/states/State_ROOM.js src/world/Cat.js src/world/Room.js`

------
https://chatgpt.com/codex/tasks/task_e_689f04b0c09c8326955d782446d40bf7