### PR TITLE
Animate cat when locked door clicked

### DIFF
--- a/src/world/Cat.js
+++ b/src/world/Cat.js
@@ -13,10 +13,15 @@ export class Cat{
     this.happy=0.5; this.full=0.5; this.play=0.5;
     this.lookAt=false; this.purr=false;
     this.dead=false;
+    this.scale=1;
   }
   tick(dt){ if(this.dead) return; this.happy = Math.max(0,Math.min(1,this.happy - dt*0.01)); this.full = Math.max(0,Math.min(1,this.full - dt*0.02)); this.play = Math.max(0,Math.min(1,this.play - dt*0.015)); }
   draw(ctx){
     ctx.save();
+    const cx=this.x+20, cy=this.y-10;
+    ctx.translate(cx,cy);
+    ctx.scale(this.scale,this.scale);
+    ctx.translate(-cx,-cy);
     if(this.dead){
       ctx.fillStyle='#500';
       ctx.fillRect(this.x-10, this.y-20, 60, 30); // blood pool


### PR DESCRIPTION
## Summary
- Animate the cat scaling toward the player once the locked door is clicked.
- Display a red RUN overlay and attempt to close the window after the cat approaches.
- Reset the door sequence state when entering the room.

## Testing
- `node --check src/world/Cat.js`
- `node --check src/states/State_ROOM.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2966ec2c8326bfca0f77d0ca7dfa